### PR TITLE
Eliminate cabal warning about non-existing file 'README.txt'.

### DIFF
--- a/Graphics/PDF/Draw.hs
+++ b/Graphics/PDF/Draw.hs
@@ -95,6 +95,7 @@ import qualified Data.ByteString.Lazy as B
 import Control.Monad.ST
 import Data.STRef
 
+import Control.Monad.Fail
 import Control.Monad.Writer.Class
 import Control.Monad.Reader.Class
 import Control.Monad.State
@@ -211,6 +212,9 @@ instance Functor Draw where
      fmap f = \m -> do { a <- m; return (f a) }
 
 instance MonadPath Draw
+
+instance MonadFail Draw where
+  fail err = error "Draw monad failed"
 
 readDrawST :: (forall s. DrawTuple s -> STRef s a) -> Draw a
 readDrawST   f   = Draw $ \env -> readSTRef   (f env) 

--- a/HPDF.cabal
+++ b/HPDF.cabal
@@ -17,7 +17,7 @@ extra-source-files:
   Test/Makefile
   Test/Penrose.hs
   Test/test.hs
-  README.txt
+  README.md
   NEWS.txt
   TODO.txt
   changelog

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,7 @@
 # For more information, see: https://github.com/commercialhaskell/stack/blob/release/doc/yaml_configuration.md
 
 # Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
-resolver: lts-13.27
+resolver: lts-14.13
 
 # Local packages, usually specified by relative directory name
 packages:

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,7 @@
 # For more information, see: https://github.com/commercialhaskell/stack/blob/release/doc/yaml_configuration.md
 
 # Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
-resolver: lts-6.14
+resolver: lts-13.27
 
 # Local packages, usually specified by relative directory name
 packages:


### PR DESCRIPTION
Change HPDF.cabal to point to README.md instead.