### PR TITLE
MonadFail instance for GHC 8.6

### DIFF
--- a/Graphics/PDF/Draw.hs
+++ b/Graphics/PDF/Draw.hs
@@ -86,6 +86,9 @@ import Data.Maybe
 #if !MIN_VERSION_base(4,8,0)
 import Data.Monoid
 #endif
+#if MIN_VERSION_base(4,11,0)
+import qualified Control.Monad.Fail as Fail
+#endif
 
 import qualified Data.Map.Strict as M
 import qualified Data.IntMap as IM
@@ -185,6 +188,11 @@ instance Monad Draw where
                           a <- unDraw m env
                           unDraw (f a) env
     return x = Draw $ \_env -> return x
+
+#if MIN_VERSION_base(4,11,0)
+instance Fail.MonadFail Draw where
+    fail s = Draw $ \_ -> Fail.fail s
+#endif
 
 instance MonadReader DrawEnvironment Draw where
    ask       = Draw $ \env -> return (drawEnvironment env)


### PR DESCRIPTION
Closes #21 

CPP-limited to `base` 4.9.0.0 and up based on the info [here](http://hackage.haskell.org/package/base-4.12.0.0/docs/Control-Monad-Fail.html).