### PR TITLE
make pattern match complete and bump LTS. avoid failable pattern in d…

### DIFF
--- a/HPDF.cabal
+++ b/HPDF.cabal
@@ -87,7 +87,8 @@ library
       text >= 1.2.0,
       network-uri >= 2.6.0.3,
       parsec >=3.1.9,
-      filepath >= 1.4.0
+      filepath >= 1.4.0,
+      inflist
   Default-language:  Haskell2010
 
   ghc-options: -Wall -fno-warn-tabs -funbox-strict-fields  -O2

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,14 +1,17 @@
 # For more information, see: https://github.com/commercialhaskell/stack/blob/release/doc/yaml_configuration.md
 
 # Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
-resolver: lts-6.14
+# resolver: lts-6.14
+resolver: lts-13.20
+
 
 # Local packages, usually specified by relative directory name
 packages:
 - '.'
 
 # Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
-extra-deps: []
+extra-deps:
+  - inflist-0.0.1@sha256:f78bb0b472e43dc475c1d9345dde5bafd554a0b780e7638235e6f25f71f3083d
 
 # Override default flag values for local packages and extra-deps
 flags: {}


### PR DESCRIPTION
…o block.

stack lts-13.20 uses ghc-8.6.5. since ghc-8.0 failable patterns in
do blocks require a MonadFail instance, or removing the failable
pattern. in this case we replace ordinary lists with infinite lists,
so the need to match on nil never arises.